### PR TITLE
Add factura-global example and README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Este projeto é uma API RESTful para gerenciar um fórum de cursos, tópicos e r
 ### **criar Perfil**
 - `POST /api/v1/users/create` - Realiza login de um usuário e retorna um token JWT para autenticação.
 
+### **Facturas**
+- `GET /api/facturas/global` - Retorna uma factura global. Exemplo em `docs/exemplos/factura-global.json`.
+
 ## Como Rodar o Projeto
 
 ### Pré-requisitos
@@ -152,6 +155,17 @@ POST /api/v1/users/create
 
 
 ```
+
+### Exemplos de Factura Global
+
+Há apenas um ficheiro de exemplo para evitar duplicação:
+
+- `docs/exemplos/factura-global.json`
+
+Se for necessário manter múltiplos exemplos no futuro, utilize o formato com sufixo e documente cada um de forma explícita, por exemplo:
+
+- `docs/exemplos/fatura-global-1.json`
+- `docs/exemplos/fatura-global-2.json`
 
 A resposta será um token JWT que deve ser enviado nas requisições subsequentes no cabeçalho `Authorization`.
 

--- a/docs/exemplos/factura-global.json
+++ b/docs/exemplos/factura-global.json
@@ -1,0 +1,31 @@
+{
+  "factura": {
+    "numero": "FG-2024-0001",
+    "data": "2024-09-01",
+    "moeda": "AOA",
+    "cliente": {
+      "nome": "Empresa Exemplo, Lda.",
+      "nif": "5001234567",
+      "email": "financeiro@exemplo.co.ao"
+    },
+    "itens": [
+      {
+        "descricao": "Licença de software",
+        "quantidade": 2,
+        "precoUnitario": 150000,
+        "total": 300000
+      },
+      {
+        "descricao": "Suporte premium",
+        "quantidade": 1,
+        "precoUnitario": 50000,
+        "total": 50000
+      }
+    ],
+    "totais": {
+      "subtotal": 350000,
+      "iva": 52500,
+      "total": 402500
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize and document the "Factura Global" example to avoid duplicate example blocks and ensure API endpoints reference a single canonical example file.

### Description
- Added `docs/exemplos/factura-global.json` and updated `README.md` to document the `GET /api/facturas/global` endpoint and the example naming convention (e.g., `fatura-global-1.json`) to prevent duplication.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847797a6e88331b93fc9a7df9f7ddf)