### PR TITLE
Adicionar backend de faturação eletrónica com endpoints e exemplos JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Este projeto é uma API RESTful para gerenciar um fórum de cursos, tópicos e r
 ### **criar Perfil**
 - `POST /api/v1/users/create` - Realiza login de um usuário e retorna um token JWT para autenticação.
 
+### **Faturação Eletrónica**
+- `GET /api/faturacao/exemplo` - Retorna um exemplo de fatura a partir de um ficheiro JSON.
+- `GET /api/faturacao/exemplos` - Retorna uma lista de faturas de exemplo a partir de um ficheiro JSON.
+- `POST /api/faturacao/faturas` - Emite uma nova fatura eletrónica.
+- `GET /api/faturacao/faturas` - Lista as faturas emitidas em memória.
+- `GET /api/faturacao/faturas/{numero}` - Consulta uma fatura pelo número.
+- `POST /api/faturacao/faturas/{numero}/cancelar` - Cancela uma fatura emitida.
+
 ## Como Rodar o Projeto
 
 ### Pré-requisitos

--- a/src/main/java/ao/okayula/forum/faturacao/controller/FaturacaoController.java
+++ b/src/main/java/ao/okayula/forum/faturacao/controller/FaturacaoController.java
@@ -1,0 +1,71 @@
+package ao.okayula.forum.faturacao.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import ao.okayula.forum.faturacao.dto.FaturaRequest;
+import ao.okayula.forum.faturacao.model.Fatura;
+import ao.okayula.forum.faturacao.service.FaturaExemploService;
+import ao.okayula.forum.faturacao.service.FaturaService;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/faturacao")
+@Validated
+public class FaturacaoController {
+
+    private final FaturaService faturaService;
+    private final FaturaExemploService exemploService;
+
+    public FaturacaoController(FaturaService faturaService, FaturaExemploService exemploService) {
+        this.faturaService = faturaService;
+        this.exemploService = exemploService;
+    }
+
+    @GetMapping("/exemplo")
+    public JsonNode obterExemploFatura() {
+        return exemploService.carregarExemploFatura();
+    }
+
+    @GetMapping("/exemplos")
+    public JsonNode obterExemplosFaturas() {
+        return exemploService.carregarExemplosFaturas();
+    }
+
+    @PostMapping("/faturas")
+    public ResponseEntity<Fatura> emitirFatura(@Valid @RequestBody FaturaRequest request) {
+        Fatura fatura = faturaService.emitirFatura(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(fatura);
+    }
+
+    @GetMapping("/faturas")
+    public List<Fatura> listarFaturas() {
+        return faturaService.listarFaturas();
+    }
+
+    @GetMapping("/faturas/{numero}")
+    public ResponseEntity<Fatura> buscarFatura(@PathVariable String numero) {
+        return faturaService.buscarFatura(numero)
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Fatura não encontrada"));
+    }
+
+    @PostMapping("/faturas/{numero}/cancelar")
+    public ResponseEntity<Fatura> cancelarFatura(@PathVariable String numero) {
+        return faturaService.cancelarFatura(numero)
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Fatura não encontrada"));
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/dto/ClienteRequest.java
+++ b/src/main/java/ao/okayula/forum/faturacao/dto/ClienteRequest.java
@@ -1,0 +1,64 @@
+package ao.okayula.forum.faturacao.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class ClienteRequest {
+
+    @NotBlank(message = "O nome do cliente é obrigatório")
+    private String nome;
+
+    @NotBlank(message = "O NIF do cliente é obrigatório")
+    private String nif;
+
+    @Email(message = "O email do cliente deve ser válido")
+    @NotBlank(message = "O email do cliente é obrigatório")
+    private String email;
+
+    @NotBlank(message = "O telefone do cliente é obrigatório")
+    private String telefone;
+
+    @Valid
+    private EnderecoRequest endereco;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getNif() {
+        return nif;
+    }
+
+    public void setNif(String nif) {
+        this.nif = nif;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public EnderecoRequest getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(EnderecoRequest endereco) {
+        this.endereco = endereco;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/dto/EnderecoRequest.java
+++ b/src/main/java/ao/okayula/forum/faturacao/dto/EnderecoRequest.java
@@ -1,0 +1,60 @@
+package ao.okayula.forum.faturacao.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class EnderecoRequest {
+
+    @NotBlank(message = "A rua é obrigatória")
+    private String rua;
+
+    @NotBlank(message = "A cidade é obrigatória")
+    private String cidade;
+
+    @NotBlank(message = "A província é obrigatória")
+    private String provincia;
+
+    @NotBlank(message = "O país é obrigatório")
+    private String pais;
+
+    private String codigoPostal;
+
+    public String getRua() {
+        return rua;
+    }
+
+    public void setRua(String rua) {
+        this.rua = rua;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public String getProvincia() {
+        return provincia;
+    }
+
+    public void setProvincia(String provincia) {
+        this.provincia = provincia;
+    }
+
+    public String getPais() {
+        return pais;
+    }
+
+    public void setPais(String pais) {
+        this.pais = pais;
+    }
+
+    public String getCodigoPostal() {
+        return codigoPostal;
+    }
+
+    public void setCodigoPostal(String codigoPostal) {
+        this.codigoPostal = codigoPostal;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/dto/FaturaItemRequest.java
+++ b/src/main/java/ao/okayula/forum/faturacao/dto/FaturaItemRequest.java
@@ -1,0 +1,57 @@
+package ao.okayula.forum.faturacao.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public class FaturaItemRequest {
+
+    @NotBlank(message = "A descrição do item é obrigatória")
+    private String descricao;
+
+    @NotNull(message = "A quantidade é obrigatória")
+    @Positive(message = "A quantidade deve ser positiva")
+    private Integer quantidade;
+
+    @NotNull(message = "O preço unitário é obrigatório")
+    @Positive(message = "O preço unitário deve ser positivo")
+    private BigDecimal precoUnitario;
+
+    @NotNull(message = "O total do item é obrigatório")
+    @Positive(message = "O total do item deve ser positivo")
+    private BigDecimal total;
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getQuantidade() {
+        return quantidade;
+    }
+
+    public void setQuantidade(Integer quantidade) {
+        this.quantidade = quantidade;
+    }
+
+    public BigDecimal getPrecoUnitario() {
+        return precoUnitario;
+    }
+
+    public void setPrecoUnitario(BigDecimal precoUnitario) {
+        this.precoUnitario = precoUnitario;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/dto/FaturaRequest.java
+++ b/src/main/java/ao/okayula/forum/faturacao/dto/FaturaRequest.java
@@ -1,0 +1,138 @@
+package ao.okayula.forum.faturacao.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public class FaturaRequest {
+
+    private String numero;
+
+    @NotNull(message = "A data de emissão é obrigatória")
+    private LocalDate dataEmissao;
+
+    @NotBlank(message = "A moeda é obrigatória")
+    private String moeda;
+
+    @Valid
+    @NotNull(message = "Os dados do cliente são obrigatórios")
+    private ClienteRequest cliente;
+
+    @Valid
+    @NotNull(message = "Os itens da fatura são obrigatórios")
+    private List<FaturaItemRequest> itens;
+
+    @NotNull(message = "O subtotal é obrigatório")
+    @Positive(message = "O subtotal deve ser positivo")
+    private BigDecimal subtotal;
+
+    @NotNull(message = "Os impostos são obrigatórios")
+    @Positive(message = "Os impostos devem ser positivos")
+    private BigDecimal impostos;
+
+    @NotNull(message = "O desconto é obrigatório")
+    private BigDecimal desconto;
+
+    @NotNull(message = "O total é obrigatório")
+    @Positive(message = "O total deve ser positivo")
+    private BigDecimal total;
+
+    @Valid
+    @NotNull(message = "O pagamento é obrigatório")
+    private PagamentoRequest pagamento;
+
+    private String status;
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public LocalDate getDataEmissao() {
+        return dataEmissao;
+    }
+
+    public void setDataEmissao(LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+
+    public String getMoeda() {
+        return moeda;
+    }
+
+    public void setMoeda(String moeda) {
+        this.moeda = moeda;
+    }
+
+    public ClienteRequest getCliente() {
+        return cliente;
+    }
+
+    public void setCliente(ClienteRequest cliente) {
+        this.cliente = cliente;
+    }
+
+    public List<FaturaItemRequest> getItens() {
+        return itens;
+    }
+
+    public void setItens(List<FaturaItemRequest> itens) {
+        this.itens = itens;
+    }
+
+    public BigDecimal getSubtotal() {
+        return subtotal;
+    }
+
+    public void setSubtotal(BigDecimal subtotal) {
+        this.subtotal = subtotal;
+    }
+
+    public BigDecimal getImpostos() {
+        return impostos;
+    }
+
+    public void setImpostos(BigDecimal impostos) {
+        this.impostos = impostos;
+    }
+
+    public BigDecimal getDesconto() {
+        return desconto;
+    }
+
+    public void setDesconto(BigDecimal desconto) {
+        this.desconto = desconto;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+
+    public PagamentoRequest getPagamento() {
+        return pagamento;
+    }
+
+    public void setPagamento(PagamentoRequest pagamento) {
+        this.pagamento = pagamento;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/dto/PagamentoRequest.java
+++ b/src/main/java/ao/okayula/forum/faturacao/dto/PagamentoRequest.java
@@ -1,0 +1,54 @@
+package ao.okayula.forum.faturacao.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public class PagamentoRequest {
+
+    @NotBlank(message = "O método de pagamento é obrigatório")
+    private String metodo;
+
+    private String referencia;
+
+    private LocalDateTime dataPagamento;
+
+    @NotNull(message = "O valor pago é obrigatório")
+    @Positive(message = "O valor pago deve ser positivo")
+    private BigDecimal valorPago;
+
+    public String getMetodo() {
+        return metodo;
+    }
+
+    public void setMetodo(String metodo) {
+        this.metodo = metodo;
+    }
+
+    public String getReferencia() {
+        return referencia;
+    }
+
+    public void setReferencia(String referencia) {
+        this.referencia = referencia;
+    }
+
+    public LocalDateTime getDataPagamento() {
+        return dataPagamento;
+    }
+
+    public void setDataPagamento(LocalDateTime dataPagamento) {
+        this.dataPagamento = dataPagamento;
+    }
+
+    public BigDecimal getValorPago() {
+        return valorPago;
+    }
+
+    public void setValorPago(BigDecimal valorPago) {
+        this.valorPago = valorPago;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/model/Cliente.java
+++ b/src/main/java/ao/okayula/forum/faturacao/model/Cliente.java
@@ -1,0 +1,50 @@
+package ao.okayula.forum.faturacao.model;
+
+public class Cliente {
+
+    private String nome;
+    private String nif;
+    private String email;
+    private String telefone;
+    private Endereco endereco;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getNif() {
+        return nif;
+    }
+
+    public void setNif(String nif) {
+        this.nif = nif;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public Endereco getEndereco() {
+        return endereco;
+    }
+
+    public void setEndereco(Endereco endereco) {
+        this.endereco = endereco;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/model/Endereco.java
+++ b/src/main/java/ao/okayula/forum/faturacao/model/Endereco.java
@@ -1,0 +1,50 @@
+package ao.okayula.forum.faturacao.model;
+
+public class Endereco {
+
+    private String rua;
+    private String cidade;
+    private String provincia;
+    private String pais;
+    private String codigoPostal;
+
+    public String getRua() {
+        return rua;
+    }
+
+    public void setRua(String rua) {
+        this.rua = rua;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public String getProvincia() {
+        return provincia;
+    }
+
+    public void setProvincia(String provincia) {
+        this.provincia = provincia;
+    }
+
+    public String getPais() {
+        return pais;
+    }
+
+    public void setPais(String pais) {
+        this.pais = pais;
+    }
+
+    public String getCodigoPostal() {
+        return codigoPostal;
+    }
+
+    public void setCodigoPostal(String codigoPostal) {
+        this.codigoPostal = codigoPostal;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/model/Fatura.java
+++ b/src/main/java/ao/okayula/forum/faturacao/model/Fatura.java
@@ -1,0 +1,108 @@
+package ao.okayula.forum.faturacao.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class Fatura {
+
+    private String numero;
+    private LocalDate dataEmissao;
+    private String moeda;
+    private Cliente cliente;
+    private List<FaturaItem> itens;
+    private BigDecimal subtotal;
+    private BigDecimal impostos;
+    private BigDecimal desconto;
+    private BigDecimal total;
+    private Pagamento pagamento;
+    private String status;
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public LocalDate getDataEmissao() {
+        return dataEmissao;
+    }
+
+    public void setDataEmissao(LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+
+    public String getMoeda() {
+        return moeda;
+    }
+
+    public void setMoeda(String moeda) {
+        this.moeda = moeda;
+    }
+
+    public Cliente getCliente() {
+        return cliente;
+    }
+
+    public void setCliente(Cliente cliente) {
+        this.cliente = cliente;
+    }
+
+    public List<FaturaItem> getItens() {
+        return itens;
+    }
+
+    public void setItens(List<FaturaItem> itens) {
+        this.itens = itens;
+    }
+
+    public BigDecimal getSubtotal() {
+        return subtotal;
+    }
+
+    public void setSubtotal(BigDecimal subtotal) {
+        this.subtotal = subtotal;
+    }
+
+    public BigDecimal getImpostos() {
+        return impostos;
+    }
+
+    public void setImpostos(BigDecimal impostos) {
+        this.impostos = impostos;
+    }
+
+    public BigDecimal getDesconto() {
+        return desconto;
+    }
+
+    public void setDesconto(BigDecimal desconto) {
+        this.desconto = desconto;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+
+    public Pagamento getPagamento() {
+        return pagamento;
+    }
+
+    public void setPagamento(Pagamento pagamento) {
+        this.pagamento = pagamento;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/model/FaturaItem.java
+++ b/src/main/java/ao/okayula/forum/faturacao/model/FaturaItem.java
@@ -1,0 +1,43 @@
+package ao.okayula.forum.faturacao.model;
+
+import java.math.BigDecimal;
+
+public class FaturaItem {
+
+    private String descricao;
+    private Integer quantidade;
+    private BigDecimal precoUnitario;
+    private BigDecimal total;
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Integer getQuantidade() {
+        return quantidade;
+    }
+
+    public void setQuantidade(Integer quantidade) {
+        this.quantidade = quantidade;
+    }
+
+    public BigDecimal getPrecoUnitario() {
+        return precoUnitario;
+    }
+
+    public void setPrecoUnitario(BigDecimal precoUnitario) {
+        this.precoUnitario = precoUnitario;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/model/Pagamento.java
+++ b/src/main/java/ao/okayula/forum/faturacao/model/Pagamento.java
@@ -1,0 +1,44 @@
+package ao.okayula.forum.faturacao.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class Pagamento {
+
+    private String metodo;
+    private String referencia;
+    private LocalDateTime dataPagamento;
+    private BigDecimal valorPago;
+
+    public String getMetodo() {
+        return metodo;
+    }
+
+    public void setMetodo(String metodo) {
+        this.metodo = metodo;
+    }
+
+    public String getReferencia() {
+        return referencia;
+    }
+
+    public void setReferencia(String referencia) {
+        this.referencia = referencia;
+    }
+
+    public LocalDateTime getDataPagamento() {
+        return dataPagamento;
+    }
+
+    public void setDataPagamento(LocalDateTime dataPagamento) {
+        this.dataPagamento = dataPagamento;
+    }
+
+    public BigDecimal getValorPago() {
+        return valorPago;
+    }
+
+    public void setValorPago(BigDecimal valorPago) {
+        this.valorPago = valorPago;
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/service/FaturaExemploService.java
+++ b/src/main/java/ao/okayula/forum/faturacao/service/FaturaExemploService.java
@@ -1,0 +1,37 @@
+package ao.okayula.forum.faturacao.service;
+
+import java.io.IOException;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class FaturaExemploService {
+
+    private final ObjectMapper objectMapper;
+
+    public FaturaExemploService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public JsonNode carregarExemploFatura() {
+        return lerJson("faturacao/exemplo-fatura.json");
+    }
+
+    public JsonNode carregarExemplosFaturas() {
+        return lerJson("faturacao/exemplo-faturas.json");
+    }
+
+    private JsonNode lerJson(String caminho) {
+        Resource resource = new ClassPathResource(caminho);
+        try {
+            return objectMapper.readTree(resource.getInputStream());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Não foi possível ler o arquivo JSON: " + caminho, ex);
+        }
+    }
+}

--- a/src/main/java/ao/okayula/forum/faturacao/service/FaturaService.java
+++ b/src/main/java/ao/okayula/forum/faturacao/service/FaturaService.java
@@ -1,0 +1,120 @@
+package ao.okayula.forum.faturacao.service;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+import ao.okayula.forum.faturacao.dto.ClienteRequest;
+import ao.okayula.forum.faturacao.dto.EnderecoRequest;
+import ao.okayula.forum.faturacao.dto.FaturaItemRequest;
+import ao.okayula.forum.faturacao.dto.FaturaRequest;
+import ao.okayula.forum.faturacao.dto.PagamentoRequest;
+import ao.okayula.forum.faturacao.model.Cliente;
+import ao.okayula.forum.faturacao.model.Endereco;
+import ao.okayula.forum.faturacao.model.Fatura;
+import ao.okayula.forum.faturacao.model.FaturaItem;
+import ao.okayula.forum.faturacao.model.Pagamento;
+
+@Service
+public class FaturaService {
+
+    private final Map<String, Fatura> faturas = new ConcurrentHashMap<>();
+    private final AtomicLong sequencia = new AtomicLong(1);
+
+    public Fatura emitirFatura(FaturaRequest request) {
+        Fatura fatura = new Fatura();
+        String numero = request.getNumero();
+        if (numero == null || numero.isBlank()) {
+            numero = gerarNumero(LocalDate.now());
+        }
+
+        fatura.setNumero(numero);
+        fatura.setDataEmissao(request.getDataEmissao());
+        fatura.setMoeda(request.getMoeda());
+        fatura.setCliente(mapCliente(request.getCliente()));
+        fatura.setItens(mapItens(request.getItens()));
+        fatura.setSubtotal(request.getSubtotal());
+        fatura.setImpostos(request.getImpostos());
+        fatura.setDesconto(request.getDesconto());
+        fatura.setTotal(request.getTotal());
+        fatura.setPagamento(mapPagamento(request.getPagamento()));
+        fatura.setStatus(request.getStatus() == null ? "EMITIDA" : request.getStatus());
+
+        faturas.put(numero, fatura);
+        return fatura;
+    }
+
+    public List<Fatura> listarFaturas() {
+        return new ArrayList<>(faturas.values());
+    }
+
+    public Optional<Fatura> buscarFatura(String numero) {
+        return Optional.ofNullable(faturas.get(numero));
+    }
+
+    public Optional<Fatura> cancelarFatura(String numero) {
+        Fatura fatura = faturas.get(numero);
+        if (fatura == null) {
+            return Optional.empty();
+        }
+        fatura.setStatus("CANCELADA");
+        return Optional.of(fatura);
+    }
+
+    private String gerarNumero(LocalDate dataEmissao) {
+        long atual = sequencia.getAndIncrement();
+        return String.format("FT-%s-%04d", Year.from(dataEmissao), atual);
+    }
+
+    private Cliente mapCliente(ClienteRequest request) {
+        Cliente cliente = new Cliente();
+        cliente.setNome(request.getNome());
+        cliente.setNif(request.getNif());
+        cliente.setEmail(request.getEmail());
+        cliente.setTelefone(request.getTelefone());
+        cliente.setEndereco(mapEndereco(request.getEndereco()));
+        return cliente;
+    }
+
+    private Endereco mapEndereco(EnderecoRequest request) {
+        if (request == null) {
+            return null;
+        }
+        Endereco endereco = new Endereco();
+        endereco.setRua(request.getRua());
+        endereco.setCidade(request.getCidade());
+        endereco.setProvincia(request.getProvincia());
+        endereco.setPais(request.getPais());
+        endereco.setCodigoPostal(request.getCodigoPostal());
+        return endereco;
+    }
+
+    private List<FaturaItem> mapItens(List<FaturaItemRequest> itens) {
+        List<FaturaItem> resultado = new ArrayList<>();
+        for (FaturaItemRequest itemRequest : itens) {
+            FaturaItem item = new FaturaItem();
+            item.setDescricao(itemRequest.getDescricao());
+            item.setQuantidade(itemRequest.getQuantidade());
+            item.setPrecoUnitario(itemRequest.getPrecoUnitario());
+            item.setTotal(itemRequest.getTotal());
+            resultado.add(item);
+        }
+        return resultado;
+    }
+
+    private Pagamento mapPagamento(PagamentoRequest request) {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setMetodo(request.getMetodo());
+        pagamento.setReferencia(request.getReferencia());
+        pagamento.setDataPagamento(request.getDataPagamento());
+        pagamento.setValorPago(request.getValorPago());
+        return pagamento;
+    }
+}

--- a/src/main/java/ao/okayula/forum/security/SecurityConfig.java
+++ b/src/main/java/ao/okayula/forum/security/SecurityConfig.java
@@ -46,7 +46,12 @@ public class SecurityConfig {
                 // Configura as regras de autorização
                 .authorizeHttpRequests(authorize -> authorize
                 // Define os endpoints públicos
-                .requestMatchers("/api/v1/users/register", "/api/v1/users/login","/api/v1/users/create").permitAll()
+                .requestMatchers(
+                        "/api/v1/users/register",
+                        "/api/v1/users/login",
+                        "/api/v1/users/create",
+                        "/api/faturacao/**")
+                .permitAll()
                 // Todas as outras solicitações requerem autenticação
                 .anyRequest().authenticated()
                 )

--- a/src/main/resources/faturacao/exemplo-fatura.json
+++ b/src/main/resources/faturacao/exemplo-fatura.json
@@ -1,0 +1,43 @@
+{
+  "numero": "FT-2024-0001",
+  "dataEmissao": "2024-11-15",
+  "moeda": "AOA",
+  "cliente": {
+    "nome": "Empresa Luanda Tech",
+    "nif": "5001234567",
+    "email": "financeiro@luandatech.ao",
+    "telefone": "+244 923 000 000",
+    "endereco": {
+      "rua": "Av. 4 de Fevereiro, 100",
+      "cidade": "Luanda",
+      "provincia": "Luanda",
+      "pais": "Angola",
+      "codigoPostal": "0000"
+    }
+  },
+  "itens": [
+    {
+      "descricao": "Licença anual do sistema",
+      "quantidade": 1,
+      "precoUnitario": 120000.00,
+      "total": 120000.00
+    },
+    {
+      "descricao": "Suporte premium",
+      "quantidade": 1,
+      "precoUnitario": 30000.00,
+      "total": 30000.00
+    }
+  ],
+  "subtotal": 150000.00,
+  "impostos": 22500.00,
+  "desconto": 0.00,
+  "total": 172500.00,
+  "pagamento": {
+    "metodo": "Transferência bancária",
+    "referencia": "TRX-2024-00045",
+    "dataPagamento": "2024-11-15T10:30:00",
+    "valorPago": 172500.00
+  },
+  "status": "EMITIDA"
+}

--- a/src/main/resources/faturacao/exemplo-faturas.json
+++ b/src/main/resources/faturacao/exemplo-faturas.json
@@ -1,0 +1,28 @@
+[
+  {
+    "numero": "FT-2024-0001",
+    "dataEmissao": "2024-11-15",
+    "moeda": "AOA",
+    "cliente": {
+      "nome": "Empresa Luanda Tech",
+      "nif": "5001234567",
+      "email": "financeiro@luandatech.ao",
+      "telefone": "+244 923 000 000"
+    },
+    "total": 172500.00,
+    "status": "EMITIDA"
+  },
+  {
+    "numero": "FT-2024-0002",
+    "dataEmissao": "2024-11-16",
+    "moeda": "AOA",
+    "cliente": {
+      "nome": "Kwanza Retail",
+      "nif": "5007654321",
+      "email": "pagamentos@kwanzaretail.ao",
+      "telefone": "+244 933 111 222"
+    },
+    "total": 98500.00,
+    "status": "PAGO"
+  }
+]


### PR DESCRIPTION
### Motivation
- Implementar um módulo de faturação electrónica simples para permitir emissão, consulta e cancelamento de faturas dentro da aplicação existente.
- Fornecer exemplos JSON para facilitar testes e documentação rápida dos formatos de fatura aceites pela API.
- Expor os endpoints de faturação como públicos para facilitar integração e demonstração sem exigir autenticação.

### Description
- Adiciona o pacote `ao.okayula.forum.faturacao` com modelos (`Fatura`, `FaturaItem`, `Cliente`, `Endereco`, `Pagamento`) e DTOs (`FaturaRequest`, `FaturaItemRequest`, `ClienteRequest`, `EnderecoRequest`, `PagamentoRequest`).
- Implementa serviços `FaturaService` (armazenamento em memória, emissão, listagem, busca e cancelamento) e `FaturaExemploService` (leitura de exemplos JSON em `src/main/resources/faturacao`).
- Cria o controller `FaturacaoController` que expõe os endpoints `GET /api/faturacao/exemplo`, `GET /api/faturacao/exemplos`, `POST /api/faturacao/faturas`, `GET /api/faturacao/faturas`, `GET /api/faturacao/faturas/{numero}` e `POST /api/faturacao/faturas/{numero}/cancelar`.
- Atualiza `SecurityConfig` para permitir acesso público a `"/api/faturacao/**"` e documenta os novos endpoints no `README.md` juntamente com dois ficheiros de exemplo `exemplo-fatura.json` e `exemplo-faturas.json`.

### Testing
- Nenhum teste automatizado foi executado como parte desta mudança (nenhum `mvn` ou suíte de testes foi rodada).
- Recomenda-se executar `mvn test` e iniciar a aplicação com `mvn spring-boot:run` para validar os endpoints localmente usando ferramentas como `curl` ou `Postman`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698471cab2cc8331ad9fbb0f364acb5b)